### PR TITLE
Refactor intrusive linked list from src/internal.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ strict_gc = []
 arrayvec = "0.4"
 crossbeam-utils = "0.1"
 lazy_static = "0.2"
+memoffset = "0.1.0"
 
 [dev-dependencies]
 rand = "0.3"

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -22,21 +22,22 @@ use std::num::Wrapping;
 use std::ptr;
 use std::sync::Arc;
 use std::sync::atomic;
-use std::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release, SeqCst};
+use std::sync::atomic::Ordering::{Acquire, Relaxed, Release, SeqCst};
 
 use crossbeam_utils::cache_padded::CachePadded;
 
-use atomic::{Atomic, Owned};
+use atomic::Owned;
 use collector::Handle;
 use epoch::{AtomicEpoch, Epoch};
 use guard::{unprotected, Guard};
 use garbage::{Bag, Garbage};
+use sync::list::{List, Entry, IterError, Container};
 use sync::queue::Queue;
 
 /// The global data for a garbage collector.
 pub struct Global {
-    /// The head pointer of the list of `Local`s.
-    head: Atomic<Local>,
+    /// The intrusive linked list of `Local`s.
+    locals: List<Local, LocalContainer>,
 
     /// The global queue of bags of deferred functions.
     queue: Queue<(Epoch, Bag)>,
@@ -53,7 +54,7 @@ impl Global {
     #[inline]
     pub fn new() -> Self {
         Self {
-            head: Atomic::null(),
+            locals: List::new(),
             queue: Queue::new(),
             epoch: CachePadded::new(AtomicEpoch::new(Epoch::starting())),
         }
@@ -110,45 +111,25 @@ impl Global {
         // TODO(stjepang): `Local`s are stored in a linked list because linked lists are fairly
         // easy to implement in a lock-free manner. However, traversal can be slow due to cache
         // misses and data dependencies. We should experiment with other data structures as well.
-        let mut pred = &self.head;
-        let mut curr = pred.load(Acquire, guard);
-
-        while let Some(c) = unsafe { curr.as_ref() } {
-            let succ = c.next.load(Acquire, guard);
-
-            if succ.tag() == 1 {
-                // This thread has exited. Try unlinking it from the list.
-                let succ = succ.with_tag(0);
-
-                if pred.compare_and_set(curr, succ, AcqRel, guard).is_err() {
+        for local in self.locals.iter(&guard) {
+            match local {
+                Err(IterError::LostRace) => {
                     // We lost the race to unlink the thread. Usually that means we should traverse
-                    // the list again from the beginning, but since another thread trying to
-                    // advance the epoch has won the race, we leave the job to that one.
+                    // the list again from the beginning, but since another thread trying to advance
+                    // the epoch has won the race, we leave the job to that one.
                     return global_epoch;
                 }
+                Ok(local) => {
+                    let local_epoch = local.epoch.load(Relaxed);
 
-                // The unlinked entry can later be freed.
-                unsafe {
-                    guard.defer(move || curr.into_owned());
+                    // If the participant was pinned in a different epoch, we cannot advance the
+                    // global epoch just yet.
+                    if local_epoch.is_pinned() && local_epoch.unpinned() != global_epoch {
+                        return global_epoch;
+                    }
                 }
-
-                // Move forward, but don't change the predecessor.
-                curr = succ;
-            } else {
-                let local_epoch = c.epoch.load(Relaxed);
-
-                // If the participant was pinned in a different epoch, we cannot advance the global
-                // epoch just yet.
-                if local_epoch.is_pinned() && local_epoch.unpinned() != global_epoch {
-                    return global_epoch;
-                }
-
-                // Move one step forward.
-                pred = &c.next;
-                curr = succ;
             }
         }
-
         atomic::fence(Acquire);
 
         // All pinned participants were pinned in the current global epoch.
@@ -164,37 +145,18 @@ impl Global {
     }
 }
 
-impl Drop for Global {
-    fn drop(&mut self) {
-        unsafe {
-            let guard = &unprotected();
-            let mut curr = self.head.load(Relaxed, guard);
-
-            while let Some(c) = curr.as_ref() {
-                let succ = c.next.load(Relaxed, guard);
-                debug_assert_eq!(succ.tag(), 1);
-
-                let o = curr.into_owned();
-                debug_assert!((*o.bag.get()).is_empty());
-                drop(o);
-
-                curr = succ;
-            }
-        }
-    }
-}
-
 /// Participant for garbage collection.
 pub struct Local {
+    /// A node in the intrusive linked list of `Local`s.
+    entry: Entry,
+
+    /// The local epoch.
+    epoch: AtomicEpoch,
+
     /// A reference to the global data.
     ///
     /// When all guards and handles get dropped, this reference is destroyed.
     global: UnsafeCell<ManuallyDrop<Arc<Global>>>,
-
-    /// Pointer to the next entry in the linked list of registered participants.
-    ///
-    /// If an entry's `next` pointer is tagged with 1, it is considered to be deleted.
-    next: Atomic<Local>,
 
     /// The local bag of deferred functions.
     pub(crate) bag: UnsafeCell<Bag>,
@@ -209,9 +171,6 @@ pub struct Local {
     ///
     /// This is just an auxilliary counter that sometimes kicks off collection.
     pin_count: Cell<Wrapping<usize>>,
-
-    /// The local epoch.
-    epoch: AtomicEpoch,
 }
 
 unsafe impl Sync for Local {}
@@ -225,34 +184,18 @@ impl Local {
     pub fn register(global: Arc<Global>) -> Handle {
         unsafe {
             // Since we dereference no pointers in this block, it is safe to use `unprotected`.
-            let guard = &unprotected();
 
-            let mut new = Owned::new(Local {
+            let local = Owned::new(Local {
+                entry: Entry::default(),
+                epoch: AtomicEpoch::new(Epoch::starting()),
                 global: UnsafeCell::new(ManuallyDrop::new(global.clone())),
-                next: Atomic::null(),
                 bag: UnsafeCell::new(Bag::new()),
                 guard_count: Cell::new(0),
                 handle_count: Cell::new(1),
                 pin_count: Cell::new(Wrapping(0)),
-                epoch: AtomicEpoch::new(Epoch::starting()),
-            });
-            let mut head = global.head.load(Acquire, guard);
-
-            loop {
-                new.next.store(head, Relaxed);
-
-                // Try installing this thread's entry as the new head.
-                match global
-                    .head
-                    .compare_and_set_weak_owned(head, new, AcqRel, guard)
-                {
-                    Ok(n) => return Handle { local: n.as_raw() },
-                    Err((h, n)) => {
-                        head = h;
-                        new = n;
-                    }
-                }
-            }
+            }).into_ptr(&unprotected());
+            global.locals.insert(local, &unprotected());
+            Handle { local: local.as_raw() }
         }
     }
 
@@ -348,7 +291,7 @@ impl Local {
             self.epoch.store(Epoch::starting(), Release);
 
             if self.handle_count.get() == 0 {
-                Self::finalize(self);
+                self.finalize();
             }
         }
     }
@@ -370,29 +313,49 @@ impl Local {
         self.handle_count.set(handle_count - 1);
 
         if guard_count == 0 && handle_count == 1 {
-            Self::finalize(self);
+            self.finalize();
         }
     }
 
     /// Removes the `Local` from the global linked list.
     #[cold]
-    pub fn finalize(&self) {
-        assert_eq!(self.guard_count.get(), 0);
-        assert_eq!(self.handle_count.get(), 0);
+    fn finalize(&self) {
+        debug_assert_eq!(self.guard_count.get(), 0);
+        debug_assert_eq!(self.handle_count.get(), 0);
 
         unsafe {
             // Take the reference to the `Global` out of this `Local`.
             let global: Arc<Global> = ptr::read(&**self.global.get());
 
             // Move the local bag into the global queue.
-            self.global().push_bag(&mut *self.bag.get(), &unprotected());
-            // Mark this node in the linked list as deleted.
-            self.next.fetch_or(1, SeqCst, &unprotected());
+            global.push_bag(&mut *self.bag.get(), &unprotected());
 
-            // Finally, drop the reference to the global.
-            // Note that this might be the last reference to the `Global`. If so, the global data
-            // will be destroyed and all deferred functions in its queue will be executed.
+            // Mark this node in the linked list as deleted.
+            self.entry.delete(&unprotected());
+
+            // Finally, drop the reference to the global.  Note that this might be the last
+            // reference to the `Global`. If so, the global data will be destroyed and all deferred
+            // functions in its queue will be executed.
             drop(global);
+        }
+    }
+}
+
+struct LocalContainer {}
+
+impl Container<Local> for LocalContainer {
+    fn container_of(entry: *const Entry) -> *const Local {
+        (entry as usize - offset_of!(Local, entry)) as *const _
+    }
+
+    fn entry_of(local: *const Local) -> *const Entry {
+        (local as usize + offset_of!(Local, entry)) as *const _
+    }
+
+    fn finalize(entry: *const Entry) {
+        let local = Self::container_of(entry);
+        unsafe {
+            drop(Box::from_raw(local as *mut Local));
         }
     }
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -113,10 +113,9 @@ impl Global {
         // misses and data dependencies. We should experiment with other data structures as well.
         for local in self.locals.iter(&guard) {
             match local {
-                Err(IterError::LostRace) => {
-                    // We lost the race to unlink the thread. Usually that means we should traverse
-                    // the list again from the beginning, but since another thread trying to advance
-                    // the epoch has won the race, we leave the job to that one.
+                Err(IterError::Stalled) => {
+                    // The iteration is stalled by another thread's iteration. Since that thread
+                    // also tries to advance the epoch, we leave the job to that thread.
                     return global_epoch;
                 }
                 Ok(local) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,8 @@ extern crate arrayvec;
 extern crate crossbeam_utils;
 #[macro_use]
 extern crate lazy_static;
+#[macro_use]
+extern crate memoffset;
 
 mod atomic;
 mod collector;

--- a/src/sync/list.rs
+++ b/src/sync/list.rs
@@ -1,0 +1,314 @@
+//! Lock-free intrusive linked list.
+//!
+//! Ideas from Michael.  High Performance Dynamic Lock-Free Hash Tables and List-Based Sets.  SPAA
+//! 2002.  http://dl.acm.org/citation.cfm?id=564870.564881
+
+use std::marker::PhantomData;
+use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
+
+use {Atomic, Ptr, Guard, unprotected};
+
+/// An entry in a linked list.
+///
+/// An Entry is accessed from multiple threads, so it would be beneficial to put it in a different
+/// cache-line than thread-local data in terms of performance.
+#[derive(Debug)]
+pub struct Entry {
+    /// The next entry in the linked list.
+    /// If the tag is 1, this entry is marked as deleted.
+    next: Atomic<Entry>,
+}
+
+/// An evidence that the type `T` contains an entry.
+///
+/// Suppose we'll maintain an intrusive linked list of type `T`. Since `List` and `Entry` types do
+/// not provide any information on `T`, we need to specify how to interact with the containing
+/// objects of type `T`. A struct of this trait provides such information.
+///
+/// `container_of()` is given a pointer to an entry, and returns the pointer to its container. On
+/// the other hand, `entry_of()` is given a pointer to a container, and returns the pointer to its
+/// corresponding entry. `finalize()` is called when an element is actually removed from the list.
+///
+/// # Example
+///
+/// ```ignore
+/// struct A {
+///     entry: Entry,
+///     data: usize,
+/// }
+///
+/// struct AEntry {}
+///
+/// impl Container<A> for AEntry {
+///     fn container_of(entry: *const Entry) -> *const A {
+///         ((entry as usize) - offset_of!(A, entry)) as *const _
+///     }
+///
+///     fn entry_of(a: *const A) -> *const Entry {
+///         ((a as usize) + offset_of!(A, entry)) as *const _
+///     }
+///
+///     fn finalize(entry: *const Entry) {
+///         // drop the box of the container
+///         unsafe { drop(Box::from_raw(Self::container_of(entry) as *mut A)) }
+///     }
+/// }
+/// ```
+///
+/// Note that there can be multiple structs that implement `Container<T>`. In most cases, each
+/// struct will represent a distinct entry in `T` so that the container can be inserted into
+/// multiple lists. For example, we can insert the following struct into two lists using `entry1`
+/// and `entry2` ans its entry:
+///
+/// ```ignore
+/// struct B {
+///     entry1: Entry,
+///     entry2: Entry,
+///     data: usize,
+/// }
+/// ```
+pub trait Container<T> {
+    fn container_of(*const Entry) -> *const T;
+    fn entry_of(*const T) -> *const Entry;
+    fn finalize(*const Entry);
+}
+
+/// A lock-free, intrusive linked list of type `T`.
+#[derive(Debug)]
+pub struct List<T, C: Container<T>> {
+    /// The head of the linked list.
+    head: Atomic<Entry>,
+
+    /// The phantom data for using `T` and `E`.
+    _marker: PhantomData<(T, C)>,
+}
+
+/// An auxiliary data for iterating over a linked list.
+pub struct Iter<'g, T, C: Container<T>> {
+    /// The guard that protects the iteration.
+    guard: &'g Guard,
+
+    /// Pointer from the predecessor to the current entry.
+    pred: &'g Atomic<Entry>,
+
+    /// The current entry.
+    curr: Ptr<'g, Entry>,
+
+    /// The phantom data for container.
+    _marker: PhantomData<(T, C)>,
+}
+
+/// An enum for iteration error.
+#[derive(PartialEq, Debug)]
+pub enum IterError {
+    /// Iterator lost a race in deleting an entry by a concurrent iterator.
+    LostRace,
+}
+
+impl Default for Entry {
+    /// Returns the empty entry.
+    fn default() -> Self {
+        Self { next: Atomic::null() }
+    }
+}
+
+impl Entry {
+    /// Marks this entry as deleted, deferring the actual deallocation to a later iteration.
+    ///
+    /// # Safety
+    ///
+    /// The entry should be a member of a linked list, and it should not have been deleted. It
+    /// should be safe to call `C::finalize` on the entry after the `guard` is dropped, where `C` is
+    /// the associated helper for the linked list.
+    pub unsafe fn delete(&self, guard: &Guard) {
+        self.next.fetch_or(1, Release, guard);
+    }
+}
+
+impl<T, C: Container<T>> List<T, C> {
+    /// Returns a new, empty linked list.
+    pub fn new() -> Self {
+        Self {
+            head: Atomic::null(),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Inserts `entry` into the head of the list.
+    ///
+    /// # Safety
+    ///
+    /// You should guarantee that:
+    ///
+    /// - `C::entry_of()` properly accesses an `Entry` in the container;
+    /// - `C::container_of()` properly accesses the object containing the entry;
+    /// - `container` is immovable, e.g. inside a `Box`;
+    /// - An entry is not inserted twice; and
+    /// - The inserted object will be removed before the list is dropped.
+    pub unsafe fn insert<'g>(&'g self, container: Ptr<'g, T>, guard: &'g Guard) {
+        let to = &self.head;
+        let entry = &*C::entry_of(container.as_raw());
+        let entry_ptr = Ptr::from_raw(entry);
+        let mut next = to.load(Relaxed, guard);
+
+        loop {
+            entry.next.store(next, Relaxed);
+            match to.compare_and_set_weak(next, entry_ptr, Release, guard) {
+                Ok(_) => break,
+                Err(n) => next = n,
+            }
+        }
+    }
+
+    /// Returns an iterator over all objects.
+    ///
+    /// # Caveat
+    ///
+    /// Every object that is inserted at the moment this function is called and persists at least
+    /// until the end of iteration will be returned. Since this iterator traverses a lock-free
+    /// linked list that may be concurrently modified, some additional caveats apply:
+    ///
+    /// 1. If a new object is inserted during iteration, it may or may not be returned.
+    /// 2. If an object is deleted during iteration, it may or may not be returned.
+    /// 3. The iteration may be aborted when it lost in a race condition. In this case, the winning
+    ///    thread will continue to iterate over the same list.
+    pub fn iter<'g>(&'g self, guard: &'g Guard) -> Iter<'g, T, C> {
+        let pred = &self.head;
+        let curr = pred.load(Acquire, guard);
+        Iter {
+            guard,
+            pred,
+            curr,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T, C: Container<T>> Drop for List<T, C> {
+    fn drop(&mut self) {
+        unsafe {
+            let guard = &unprotected();
+            let mut curr = self.head.load(Relaxed, guard);
+            while let Some(c) = curr.as_ref() {
+                let succ = c.next.load(Relaxed, guard);
+                assert_eq!(succ.tag(), 1);
+
+                C::finalize(curr.as_raw());
+                curr = succ;
+            }
+        }
+    }
+}
+
+impl<'g, T: 'g, C: Container<T>> Iterator for Iter<'g, T, C> {
+    type Item = Result<&'g T, IterError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(c) = unsafe { self.curr.as_ref() } {
+            let succ = c.next.load(Acquire, self.guard);
+
+            if succ.tag() == 1 {
+                // This entry was removed. Try unlinking it from the list.
+                let succ = succ.with_tag(0);
+
+                match self.pred.compare_and_set_weak(
+                    self.curr,
+                    succ,
+                    Acquire,
+                    self.guard,
+                ) {
+                    Ok(_) => {
+                        unsafe {
+                            // Deferred drop of `T` is scheduled here.
+                            // This is okay because `.delete()` can be called only if `T: 'static`.
+                            let p = self.curr;
+                            self.guard.defer(move || C::finalize(p.as_raw()));
+                        }
+                        self.curr = succ;
+                    }
+                    Err(succ) => {
+                        // We lost the race to delete the entry by a concurrent iterator. Set
+                        // `self.curr` to the updated pointer, and report the lost.
+                        self.curr = succ;
+                        return Some(Err(IterError::LostRace));
+                    }
+                }
+
+                continue;
+            }
+
+            // Move one step forward.
+            self.pred = &c.next;
+            self.curr = succ;
+
+            return Some(Ok(unsafe { &*C::container_of(c as *const _) }));
+        }
+
+        // We reached the end of the list.
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {Collector, Owned};
+    use super::*;
+
+    #[test]
+    fn insert_iter_delete_iter() {
+        let collector = Collector::new();
+        let handle = collector.handle();
+        let guard = handle.pin();
+
+        struct EntryContainer {}
+
+        impl Container<Entry> for EntryContainer {
+            fn container_of(entry: *const Entry) -> *const Entry {
+                entry
+            }
+
+            fn entry_of(entry: *const Entry) -> *const Entry {
+                entry
+            }
+
+            fn finalize(entry: *const Entry) {
+                unsafe {
+                    drop(Box::from_raw(entry as *mut Entry))
+                }
+            }
+        }
+
+        let l: List<Entry, EntryContainer> = List::new();
+
+        let n1 = Owned::new(Entry::default()).into_ptr(&guard);
+        let n2 = Owned::new(Entry::default()).into_ptr(&guard);
+        let n3 = Owned::new(Entry::default()).into_ptr(&guard);
+
+        unsafe {
+            l.insert(n3, &guard);
+            l.insert(n2, &guard);
+            l.insert(n1, &guard);
+        }
+
+        let mut iter = l.iter(&guard);
+        assert!(iter.next().is_some());
+        assert!(iter.next().is_some());
+        assert!(iter.next().is_some());
+        assert!(iter.next().is_none());
+
+        unsafe { n2.as_ref().unwrap().delete(&guard); }
+
+        let mut iter = l.iter(&guard);
+        assert!(iter.next().is_some());
+        assert!(iter.next().is_some());
+        assert!(iter.next().is_none());
+
+        unsafe {
+            n1.as_ref().unwrap().delete(&guard);
+            n3.as_ref().unwrap().delete(&guard);
+        }
+
+        let mut iter = l.iter(&guard);
+        assert!(iter.next().is_none());
+    }
+}

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,3 +1,4 @@
 //! Synchronization primitives.
 
+pub mod list;
 pub mod queue;


### PR DESCRIPTION
Hi Stjepan,

I added an implemntation of concurrent intrusive linked list in `sync/list.rs`, and then use it in `src/internal.rs`.  Would you please review my patch, and merge it into your guard PR?

Note that the core design and terminology follows from Linux's `list.h`.  For example, I renamed `Node` into `Entry`.

Thanks!
Jeehoon